### PR TITLE
Passed data through htmlentities() to prevent Cross-Site-Scripting (XSS)

### DIFF
--- a/ssp.php
+++ b/ssp.php
@@ -52,7 +52,7 @@ class SSP {
                     $row[ $column['dt'] ] = ($isJoin) ? $column['formatter']( $data[$i][ $column['field'] ], $data[$i] ) : $column['formatter']( $data[$i][ $column['db'] ], $data[$i] );
                 }
                 else {
-                    $row[ $column['dt'] ] = ($isJoin) ? $data[$i][ $columns[$j]['field'] ] : $data[$i][ $columns[$j]['db'] ];
+                    $row[ $column['dt'] ] = htmlentities( ($isJoin) ? $data[$i][ $columns[$j]['field'] ] : $data[$i][ $columns[$j]['db'] ] );
                 }
             }
 


### PR DESCRIPTION
I had tested for XSS across my website which I was developing using CakePHP, I thought I had striped off all user input of HTML tags, until I visited the page containing the Datatable table and was alerted with "123" which was made possible by having a field in the table containing ```<script>alert(123)</script>```. I modified data_output() function so that it neutralizes HTML tags off any field that isn't being formatted. I hope it will help others using this library prevent XSS across their website. Cheers!. 

