### PR TITLE
Changing column names

### DIFF
--- a/ssp.php
+++ b/ssp.php
@@ -109,6 +109,10 @@ class SSP {
                 $columnIdx = array_search( $requestColumn['data'], $dtColumns );
                 $column = $columns[ $columnIdx ];
 
+                if (strpos($column['db'], 'AS') !== FALSE) {
+                    $column['db'] = explode('AS', $column['db'])[0];
+                }
+
                 if ( $requestColumn['orderable'] == 'true' ) {
                     $dir = $request['order'][$i]['dir'] === 'asc' ?
                         'ASC' :
@@ -155,6 +159,10 @@ class SSP {
                 $columnIdx = array_search( $requestColumn['data'], $dtColumns );
                 $column = $columns[ $columnIdx ];
 
+                if (strpos($column['db'], 'AS') !== FALSE) {
+                    $column['db'] = explode('AS', $column['db'])[0];
+                }
+
                 if ( $requestColumn['searchable'] == 'true' ) {
                     $binding = SSP::bind( $bindings, '%'.$str.'%', PDO::PARAM_STR );
                     $globalSearch[] = ($isJoin) ? $column['db']." LIKE ".$binding : "`".$column['db']."` LIKE ".$binding;
@@ -167,6 +175,10 @@ class SSP {
             $requestColumn = $request['columns'][$i];
             $columnIdx = array_search( $requestColumn['data'], $dtColumns );
             $column = $columns[ $columnIdx ];
+
+            if (strpos($column['db'], 'AS') !== FALSE) {
+                    $column['db'] = explode('AS', $column['db'])[0];
+                }
 
             $str = $requestColumn['search']['value'];
 


### PR DESCRIPTION
Recently i had issue when i was using renaming columns using AS using joined tables because some tables have same column names.
I was getting error `undefined index: novi_naziv` and search on column header and search input was not working.

```
$columns = array(
            array('db' => 'c.naziv AS novi_naziv', 'dt' => 1, 'field' => 'novi_naziv')
);

```

Using same name in fields was causing that i had same output in 2 columns in datatables, so i needed to use AS to change column name for joined tables, this is example for this scenario, you can see on image below also

```
$columns = array(
            array('db' => 'a.naziv', 'dt' => 1, 'field' => 'naziv'),
            array('db' => 'c.naziv', 'dt' => 2, 'field' => 'naziv')
);

```
![error](https://user-images.githubusercontent.com/6069979/208253926-9c961c0d-9c29-4554-a998-e6826fd4ec48.jpg)

FIX for this, at least it works for me

```
if (strpos($column['db'], 'AS') !== FALSE) {
    $column['db'] = explode('AS', $column['db'])[0];
}

```
those changes was made in those functions in SSP class

```
function order()
function filter()
```